### PR TITLE
fix: repoint repo refs to mavogel org and fix release pipeline

### DIFF
--- a/.codegraph/.gitignore
+++ b/.codegraph/.gitignore
@@ -1,0 +1,5 @@
+# CodeGraph data files — local to each machine, not for committing.
+# Ignore everything in .codegraph/ except this file itself, so transient
+# files (the database, daemon.pid, sockets, logs) never show up in git.
+*
+!.gitignore

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -385,13 +385,13 @@
       },
       "steps": [
         {
-          "exec": "npx npm-check-updates@20 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@aws-sdk/client-cloudwatch,@aws-sdk/client-dynamodb,@aws-sdk/client-ec2,@aws-sdk/client-eventbridge,@aws-sdk/client-secrets-manager,@aws-sdk/client-ssm,@aws-sdk/lib-dynamodb,@types/aws-lambda,@types/jest,@types/jsdom,esbuild,eslint-import-resolver-typescript,eslint-plugin-import,jest,jsii-diff,jsii-pacmak,projen,ts-jest,ts-node,typescript,node-html-parser"
+          "exec": "npx npm-check-updates@20 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@aws-sdk/client-cloudwatch,@aws-sdk/client-dynamodb,@aws-sdk/client-ec2,@aws-sdk/client-eventbridge,@aws-sdk/client-secrets-manager,@aws-sdk/client-ssm,@aws-sdk/lib-dynamodb,@types/aws-lambda,@types/jest,@types/jsdom,esbuild,eslint-import-resolver-typescript,eslint-plugin-import,jest,jsii-diff,jsii-pacmak,ts-jest,ts-node,typescript,node-html-parser"
         },
         {
           "exec": "npm install"
         },
         {
-          "exec": "npm update @aws-cdk/integ-runner @aws-cdk/integ-tests-alpha @aws-sdk/client-cloudwatch @aws-sdk/client-dynamodb @aws-sdk/client-ec2 @aws-sdk/client-eventbridge @aws-sdk/client-secrets-manager @aws-sdk/client-ssm @aws-sdk/lib-dynamodb @commitlint/cli @commitlint/config-conventional @stylistic/eslint-plugin @types/aws-lambda @types/jest @types/jsdom @types/node @typescript-eslint/eslint-plugin @typescript-eslint/parser awslint commit-and-tag-version esbuild eslint-import-resolver-typescript eslint-plugin-import eslint husky jest jest-junit jsii-diff jsii-docgen jsii-pacmak jsii-rosetta jsii projen ts-jest ts-node typescript node-html-parser aws-cdk-lib constructs @mavogel/mvc-projen cdk-nag"
+          "exec": "npm update @aws-cdk/integ-runner @aws-cdk/integ-tests-alpha @aws-sdk/client-cloudwatch @aws-sdk/client-dynamodb @aws-sdk/client-ec2 @aws-sdk/client-eventbridge @aws-sdk/client-secrets-manager @aws-sdk/client-ssm @aws-sdk/lib-dynamodb @commitlint/cli @commitlint/config-conventional @stylistic/eslint-plugin @types/aws-lambda @types/jest @types/jsdom @types/node @typescript-eslint/eslint-plugin @typescript-eslint/parser awslint commit-and-tag-version esbuild eslint-import-resolver-typescript eslint-plugin-import eslint husky jest jest-junit jsii-diff jsii-docgen jsii-pacmak jsii-rosetta jsii ts-jest ts-node typescript node-html-parser aws-cdk-lib constructs @mavogel/mvc-projen cdk-nag"
         },
         {
           "exec": "npx projen"

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -9,12 +9,24 @@ const project = new MvcCdkConstructLibrary({
   packageName: '@mavogel/cdk-vscode-server',
   packageManager: javascript.NodePackageManager.NPM,
   projenrcTs: true,
-  repositoryUrl: 'https://github.com/MV-Consulting/cdk-vscode-server.git',
+  repositoryUrl: 'https://github.com/mavogel/cdk-vscode-server.git',
   keywords: ['aws', 'cdk', 'vscode', 'construct', 'server'],
   deps: [
     '@mavogel/mvc-projen@^0.0.25',
     'constructs@^10.4.2',
   ],
+  // `@mavogel/mvc-projen` pins its own `projen` dependency (currently ^0.99.34).
+  // The default UpgradeDependencies task bumps this project's top-level `projen`
+  // devDependency independently (e.g. to 0.101.x), which drifts out of that range:
+  // npm then installs a second, nested `projen` for mvc-projen's synthesis, so the
+  // generated release workflow's builtin task names (from the nested version) no
+  // longer match what the top-level `projen` CLI can resolve at runtime, breaking
+  // `npx projen release` with "Cannot find module '.../bump-version.task.js'".
+  // Exclude `projen` from auto-upgrade so it stays aligned with mvc-projen's pin;
+  // bump it deliberately alongside a `@mavogel/mvc-projen` version bump instead.
+  depsUpgradeOptions: {
+    exclude: ['projen'],
+  },
   // If this module is not jsii-enabled, it must also be declared under bundledDependencie
   bundledDeps: ['node-html-parser'],
   description: 'Running VS Code Server on AWS',
@@ -62,7 +74,7 @@ const project = new MvcCdkConstructLibrary({
   // see details for each: https://github.com/cdklabs/publib
   // Go
   // publishToGo: {
-  //   moduleName: 'github.com/MV-Consulting/cdk-vscode-server',
+  //   moduleName: 'github.com/mavogel/cdk-vscode-server',
   //   githubTokenSecret: 'PROJEN_GITHUB_TOKEN',
   // },
   // see https://github.com/cdklabs/publib/issues/1305

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-![Source](https://img.shields.io/github/stars/MV-Consulting/cdk-vscode-server?logo=github&label=GitHub%20Stars)
-[![Build Status](https://github.com/MV-Consulting/cdk-vscode-server/actions/workflows/build.yml/badge.svg)](https://github.com/MV-Consulting/cdk-vscode-server/actions/workflows/build.yml)
+![Source](https://img.shields.io/github/stars/mavogel/cdk-vscode-server?logo=github&label=GitHub%20Stars)
+[![Build Status](https://github.com/mavogel/cdk-vscode-server/actions/workflows/build.yml/badge.svg)](https://github.com/mavogel/cdk-vscode-server/actions/workflows/build.yml)
 [![ESLint Code Formatting](https://img.shields.io/badge/code_style-eslint-brightgreen.svg)](https://eslint.org)
-[![Latest release](https://img.shields.io/github/release/MV-Consulting/cdk-vscode-server.svg)](https://github.com/MV-Consulting/cdk-vscode-server/releases)
-![GitHub](https://img.shields.io/github/license/MV-Consulting/cdk-vscode-server)
+[![Latest release](https://img.shields.io/github/release/mavogel/cdk-vscode-server.svg)](https://github.com/mavogel/cdk-vscode-server/releases)
+![GitHub](https://img.shields.io/github/license/mavogel/cdk-vscode-server)
 [![npm](https://img.shields.io/npm/dt/@mavogel/cdk-vscode-server?label=npm&color=orange)](https://www.npmjs.com/package/@mavogel/cdk-vscode-server)
 [![typescript](https://img.shields.io/badge/jsii-typescript-blueviolet.svg)](https://www.npmjs.com/package/@mavogel/cdk-vscode-server)
 

--- a/docs/plans/2026-08-09-cdk-nag-v3-migration.md
+++ b/docs/plans/2026-08-09-cdk-nag-v3-migration.md
@@ -1,0 +1,152 @@
+# CDK-Nag v3 Migration Implementation Plan
+
+Created: 2026-08-09
+Author: info@manuel-vogel.de
+Agent: Claude Code
+Status: PENDING
+Approved: Yes
+Iterations: 0
+Worktree: No
+Type: Feature
+
+## Summary
+
+**Goal:** Upgrade `@mavogel/mvc-projen` to its latest published version (`0.0.30`), which forces `cdk-nag@^3.0.1`, bump `aws-cdk-lib` to `2.261.0` to satisfy cdk-nag v3's `>=2.257.0` floor, and migrate all 19 existing `NagSuppressions` call sites across 7 source files to cdk-nag v3's `Validations.of(...).acknowledge(...)` API so the construct still suppresses its known findings and the test suite still asserts zero unacknowledged violations.
+
+## Out of Scope
+
+- Running `npm run integ-test` (real multi-region AWS deployment) — this plan verifies via local build/lint/synth/snapshot only.
+- Bumping `aws-cdk-lib` beyond `2.261.0` to the newest npm release (`2.263.0`) — user chose the version `@mavogel/mvc-projen`'s own migration already validated end-to-end.
+- Any `@mavogel/mvc-projen` version beyond `^0.0.30` (latest published as of this plan).
+- Re-running the release pipeline / publishing this bump — separate from this plan.
+
+## Approach
+
+**Chosen:** Mirror `@mavogel/mvc-projen`'s own validated cdk-nag v2→v3 migration (commit `76fddc5` in `/Users/mavogel/Developer/projects/mvc-projen`), adapted to this repo's 19 suppression call sites across `src/suppress-nags.ts`, `src/vscode-server.ts`, `src/installer/installer.ts`, `src/secret-retriever/secret-retriever.ts`, `src/idle-monitor-enabler/idle-monitor-enabler.ts`, `src/idle-monitor/idle-monitor.ts`, and `src/prefixlist-retriever/prefixlist-retriever.ts`.
+**Why:** That commit already proved the exact API shapes end-to-end against real `aws-cdk-lib@2.261.0` + `cdk-nag@3.0.1` (the author built a standalone harness to confirm 0 unacknowledged violations), so this plan reuses a validated pattern instead of guessing at cdk-nag v3's new API from its changelog alone.
+
+## Global Constraints
+
+- `@mavogel/mvc-projen@^0.0.30` in `.projenrc.ts` `deps` (was `^0.0.25`).
+- `cdkVersion: '2.261.0'` in `.projenrc.ts` (was `'2.190.0'`).
+- `cdk-nag@^3.0.1` — auto-added by `MvcCdkConstructLibrary` once `@mavogel/mvc-projen` is bumped; do not add it manually in `.projenrc.ts` `deps`.
+- Top-level `projen` devDependency must be re-aligned to `^0.101.31` (the version `@mavogel/mvc-projen@0.0.30` itself depends on) — same single-deduped-install reasoning as the prior release-pipeline fix; the existing `depsUpgradeOptions: { exclude: ['projen'] }` guard in `.projenrc.ts` stays as-is (it only blocks the *automated* weekly upgrade from drifting `projen` again, not this deliberate manual bump).
+
+## Context for Implementer
+
+cdk-nag v3 replaces its old `IAspect`-based suppression engine with CDK's native `IPolicyValidationPlugin`/`Validations` framework. Six things matter here:
+
+1. **`NagSuppressions` is fully removed** from cdk-nag v3's public API (verified against the published `cdk-nag@3.0.2` package — no export in any `lib/*.d.ts`). The code will fail to *compile* immediately after the dependency bump lands; this is the expected signal that the migration is required, not a bug to work around. There is no way to land the dependency bump and the suppression-call-site migration as two separately-green tasks — cdk-nag v2 and v3 cannot coexist in one `node_modules` tree, so Task 1 below intentionally bundles both.
+
+2. **Full call-site inventory (verified by `grep -rn "NagSuppressions\." src/`, 19 call sites across 7 files, all importing NagSuppressions from cdk-nag):**
+
+   | File | Call sites | Notes |
+   |------|-----------|-------|
+   | `src/suppress-nags.ts` | 1 | Uses `addResourceSuppressionsByPath` — see item 3 below |
+   | `src/vscode-server.ts` | 9 | Plain `addResourceSuppressions`; includes the IAM4/IAM5 sites noted in item 4 |
+   | `src/installer/installer.ts` | 3 | One call uses `appliesTo: ['Resource::*']` on `AwsSolutions-IAM5` — a granular finding, see item 4 |
+   | `src/secret-retriever/secret-retriever.ts` | 2 | Plain `addResourceSuppressions`, includes an `IAM4` on a Lambda default execution role |
+   | `src/idle-monitor-enabler/idle-monitor-enabler.ts` | 2 | Plain `addResourceSuppressions`, includes an `IAM4` on a Lambda default execution role |
+   | `src/idle-monitor/idle-monitor.ts` | 1 | Plain `addResourceSuppressions`, includes `IAM4` + `IAM5` |
+   | `src/prefixlist-retriever/prefixlist-retriever.ts` | 1 | Plain `addResourceSuppressions`, `IAM5` |
+
+   Every plain-id call site's third positional argument is `true` (v2's `applyToChildren`) and every resource argument is either a single construct or a single-element array — no call site suppresses more than one resource at once.
+
+3. **`suppress-nags.ts:9` uses `addResourceSuppressionsByPath(stack, path, [{id, reason}])`** — a stack + CloudFormation-path-string form, not a construct instance, so it has no direct `Validations.of(construct)` target. `Validations` operates on construct instances, so the migration must first resolve the construct at that path: `Node.of(stack).findAll().find(c => c.node.path === '<path-without-leading-slash-and-stack-name>')` (the v2 path argument `` `/${stack.stackName}/AWS679f53fac002430cb0da5b7982bd2287/Resource` `` is the CDK construct path, minus the leading slash, relative to `app`, not `stack` — resolve exactly against what `Node.of(stack).findAll()` returns before assuming the string form is directly reusable). If no construct exists at that exact path (i.e. it only exists in the synthesized template, not the construct tree), acknowledge on the nearest resolvable ancestor construct instead and note the substitution in the task's completion notes.
+
+4. **Granular per-resource finding ids — not limited to IAM4/IAM5, and not limited to a fixed applyToChildren cascade.** cdk-nag v3 reports a *granular* id embedding the specific managed-policy or resource ARN for any rule that inherently varies per-resource (confirmed for `AwsSolutions-IAM4`/`AwsSolutions-IAM5` against mvc-projen's own migrated example, `assets/cdk-construct/src_crd-example.ts`), e.g. `AwsSolutions-IAM5[Resource::<SomeLogicalId.Arn>:*]` or `AwsSolutions-IAM4[Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole]`. `Validations.of(x).acknowledge({id, reason})` rejects any id containing more than one `::` (`aws-cdk-lib`'s internal `Validations.qualifyId` validator), so these granular findings need the bypass helper mvc-projen already wrote and validated:
+
+   ```typescript
+   function acknowledgeGranularFinding(construct: Construct, id: string, reason: string): void {
+     construct.node.addMetadata(Validations.ACKNOWLEDGED_RULES_METADATA_KEY, { [id]: reason });
+   }
+   ```
+
+   Separately, v2's third `true` argument (`applyToChildren`) has **no stated v3 equivalent** — `acknowledge()`/the metadata bypass are per-construct, with no built-in cascade to CDK-generated children (e.g. a `Provider`'s internal `LogRetention`/framework-onEvent constructs). A suppression that relied on `applyToChildren` may reappear as a violation on a child construct v3 reports separately.
+
+   Because of both points, the exact set of ids and the constructs they must be acknowledged on **cannot be fully predicted from reading the v2 code** — they depend on this repo's specific construct ids, attached policies, and whatever child constructs v3 walks into. Task 1's recipe: migrate every call site to `Validations`/the bypass helper using the v2 id as a first guess, run the rewritten cdk-nag test with `verbose: true`, read every reported violation id from `policy-validation-report.json`, and add one `acknowledge()`/`acknowledgeGranularFinding()` call per reported id — for ANY rule, not only IAM4/IAM5 — until the violation count is 0. Do not hand-author guessed granular ids; every granular id in the final diff must have been copied from an actual report run.
+
+5. **`suppress-nags.ts`'s target, `AWS679f53fac002430cb0da5b7982bd2287`, is a CDK-owned singleton Lambda logical id** (from CDK's built-in `AwsCustomResource`), which can change across a version jump this large. If it isn't found at the expected path, don't force an ancestor acknowledgement first — check whether the `AwsSolutions-L1` entry in `policy-validation-report.json` names a different path for the same singleton, and acknowledge there instead; only fall back to the nearest ancestor if the finding doesn't appear at all.
+
+6. **Two artifacts outside `src/` reference cdk-nag and are not part of the migration itself:**
+   - `mavogelcdkvscodeserver/` (committed Go bindings, generated by `jsii-pacmak`) pins `github.com/cdklabs/cdk-nag-go/cdknag/v2` in `go.mod` and `jsii/jsii.go`. `publishToGo` is commented out in `.projenrc.ts` (confirmed), so `npx projen build`/`package-all` does not regenerate this directory — it's a pre-existing stale artifact, unrelated to this migration. Leave it untouched (mention, don't fix, per lineage rules) rather than hand-editing it to reference `cdknag/v3`.
+   - `renovate.json5` lists `cdk-nag` inside its Renovate-ignore array, but the file carries a `~~ Generated by projen` banner — it's fully regenerated by `npx projen` from `.projenrc.ts`'s `renovatebotOptions`, so no manual edit is needed there.
+
+## Assumptions
+
+- `Validations` (with `.of()`, `.acknowledge()`, `ACKNOWLEDGED_RULES_METADATA_KEY`) and `AwsSolutionsChecks`'s new `(app, options)` constructor signature exist in `aws-cdk-lib@2.261.0` / `cdk-nag@3.0.1` exactly as used in mvc-projen's validated migration — not independently re-verified against those exact versions' own `.d.ts` in this planning session (they aren't installed yet). Task 1's first step (below) verifies this immediately after `npm install`, before any source file is touched, specifically because the fallback is NOT "adjust syntax mechanically" for every case: if `ACKNOWLEDGED_RULES_METADATA_KEY` is not publicly exported, the granular-finding bypass helper — the plan's only mechanism for IAM4/IAM5 and other ARN-embedded findings — has no implementation and there is no fallback within this plan's approach. In that case, stop and report back rather than improvising a metadata key string or a different bypass mechanism (that would be a design change, not a mechanical syntax fix).
+
+## Risks and Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Guessed/incomplete granular finding ids (any rule, not just IAM4/IAM5) leave real findings silently unacknowledged, and the test passes anyway | Medium | Medium | Task 1's DoD requires an observed 0-violation run (via the report), not just "code compiles" — ids are discovered empirically from actual report output, never hand-guessed |
+| `Validations`/`ACKNOWLEDGED_RULES_METADATA_KEY` API differs from or is absent in the actual installed `aws-cdk-lib@2.261.0`/`cdk-nag@3.0.1` | Low | High | Task 1's first step verifies the API shape immediately after `npm install`, before touching any source file; absence of the metadata key export is a stop-and-report condition, not an improvised workaround |
+| The 71-minor-version `aws-cdk-lib` jump (2.190.0 → 2.261.0) changes CDK L2 default behavior beyond cdk-nag itself (VPC/CloudFront/Lambda/etc. defaults), silently altering the deployed stack | Medium | High | Task 2 requires a manual review of the regenerated Jest snapshot diff — not a blind `jest -u` accept — and any security- or behavior-relevant change gets called out explicitly in the completion report |
+| jsii 5.9→6.0 (bundled with the `@mavogel/mvc-projen` bump) breaks `jsii-diff`/`jsii-pacmak`/docgen compatibility | Low | Medium | Covered by Task 2's full `npx projen build`, which runs all three; any incompatibility surfaces as a build failure to fix before the plan is done |
+| Task 1's long red-build window (7 files + regenerated lockfile) has no stated recovery point if the Validations API assumption fails mid-migration | Low | Medium | Key Decisions below requires a clean git checkpoint (commit hash noted, or a user-approved commit/stash) before `npx projen` runs, so an abort can restore the pre-migration green v2 tree via `git reset --hard <hash>` (with user permission) followed by `npm ci` to rebuild `node_modules` at the v2 lockfile — a bare git restore alone leaves a v3 `node_modules` behind |
+
+## Progress Tracking
+
+- [ ] Task 1: Bump mvc-projen/cdkVersion and migrate cdk-nag v2 → v3
+- [ ] Task 2: Regenerate snapshots and verify full build
+
+## Implementation Tasks
+
+### Task 1: Bump mvc-projen/cdkVersion and migrate cdk-nag v2 → v3
+
+**Objective:** Bump `@mavogel/mvc-projen` to `^0.0.30` and `cdkVersion` to `2.261.0` in `.projenrc.ts`, re-synth the generated project files, verify the `Validations` API shape actually installed, then migrate every `NagSuppressions` call site across all 7 affected source files (see Context item 2's inventory table) plus the cdk-nag test block in `test/vscode-server.test.ts` to cdk-nag v3's `Validations` API, discovering the exact granular finding ids empirically. Also updates `CLAUDE.md`'s stale "CDK-nag Integration" section and sweeps README/examples for any other stale reference.
+
+**Files:**
+
+- Modify: `.projenrc.ts` (`deps` mvc-projen version, `cdkVersion`)
+- Modify: `package.json`, `package-lock.json`, `.projen/tasks.json`, `.projen/deps.json`, `.projen/files.json` (regenerated by `npx projen`, not hand-edited)
+- Modify: `src/suppress-nags.ts`
+- Modify: `src/vscode-server.ts`
+- Modify: `src/installer/installer.ts`
+- Modify: `src/secret-retriever/secret-retriever.ts`
+- Modify: `src/idle-monitor-enabler/idle-monitor-enabler.ts`
+- Modify: `src/idle-monitor/idle-monitor.ts`
+- Modify: `src/prefixlist-retriever/prefixlist-retriever.ts`
+- Modify: `test/vscode-server.test.ts`
+- Modify: `CLAUDE.md`
+
+**Key Decisions / Notes:**
+
+- **Checkpoint first:** ensure the working tree is clean and note the current commit hash before running `npx projen` — this task's red-build window spans 7 source files and a regenerated lockfile. If the Assumptions section's API-shape bet turns out wrong and Task 1 must be aborted, the recovery path is `git reset --hard <checkpoint-hash>` (ask the user for permission first — this discards the in-progress migration) followed by `npm ci` to rebuild `node_modules` back at the v2 lockfile; a bare `git checkout` of individual files would leave a v3 `node_modules` installed against v2 source.
+- **Verify the API before migrating any source file:** after `npm install` picks up the bumped deps, read `node_modules/aws-cdk-lib/core/lib/validation/*.d.ts` and confirm `Validations.of()`, `.acknowledge()`, `.addPlugins()`, and `ACKNOWLEDGED_RULES_METADATA_KEY` are exported as used in mvc-projen's reference migration, and confirm `cdk-nag`'s `AwsSolutionsChecks` constructor accepts `(app, options)`. If `ACKNOWLEDGED_RULES_METADATA_KEY` (or any of the above) is missing or shaped differently, STOP — do not improvise a different bypass mechanism — revert to the checkpoint and report back.
+- Same version-alignment reasoning as the prior release-pipeline `/fix`: after bumping `@mavogel/mvc-projen`, also `npm install --save-dev projen@^0.101.31` (or let `npx projen` re-resolve it) so the top-level `projen` matches what `0.0.30` needs — a single deduped install, not a nested copy with mismatched builtin task names.
+- Follow the `Context for Implementer` recipe (items 2–4) for the full inventory, the `addResourceSuppressionsByPath` construct-resolution step in `suppress-nags.ts`, and the empirical granular-id discovery loop covering every rule (not only IAM4/IAM5).
+- Test rewrite pattern (mirrors mvc-projen's validated `assets/cdk-construct/test_index.test.ts`): construct `app` as `new App({ context: { '@aws-cdk/core:validationReportJson': true } })`; register the plugin via `Validations.of(app).addPlugins(new AwsSolutionsChecks(app, { verbose: true }))`; replace the two existing `Annotations.fromStack(...).findWarning/findError` tests with a single test that calls `app.synth()`, reads `<assembly.directory>/policy-validation-report.json` (treat a missing file as zero violations rather than throwing — some CDK versions omit the report entirely when there is nothing to report), flat-maps `pluginReports[].violations`, and asserts the array has length 0. Additionally assert the report/plugin actually ran against the full construct tree (e.g. a non-empty `pluginReports` array, or a known-nonzero count of acknowledged rules) so an accidentally-under-synthesized app can't produce a false-positive 0.
+- The scope moves from stack-level (`Aspects.of(stack)`, v2) to app-level (`Validations.of(app)`, v3), and the single `violations` array replaces two separate warning/error assertions. Confirm `violations` merges both severities (not just errors) by temporarily removing one known `acknowledge()` call and re-running the test — it must reappear as a violation — before restoring it; note the confirmed severity behavior in the completion report rather than assuming it from the API name.
+- Update `CLAUDE.md` line ~201 ("Apply suppressions via `NagSuppressions.addResourceSuppressions()`") to describe `Validations.of(...).acknowledge(...)` instead. Also run `grep -rn "NagSuppressions\|cdk-nag" README.md examples/ API.md renovate.json5 .projenrc.ts` and update any other stale reference found in the same change (Context item 6 already covers why `renovate.json5` itself needs no manual edit).
+- In the completion report, list every acknowledged id (plain and granular) mapped to the v2 suppression it replaces, so any dropped or newly-appeared id is visible rather than silently absorbed into a passing test.
+
+**Definition of Done:**
+
+- [ ] `package.json` shows `@mavogel/mvc-projen: ^0.0.30`, `cdk-nag: ^3.0.1`, and `aws-cdk-lib` peer/dev at `2.261.0`/`^2.261.0`
+- [ ] `grep -rn "from 'cdk-nag'" src/` shows no `NagSuppressions` import anywhere (all 7 previously-importing files migrated)
+- [ ] The rewritten cdk-nag test in `test/vscode-server.test.ts` observes 0 entries in `policy-validation-report.json`'s violations when run, and confirms the plugin actually executed (non-empty report / non-zero acknowledged-rule count)
+- [ ] Verify: `npx jest test/vscode-server.test.ts -t "cdk-nag"` passes (0 failures)
+
+### Task 2: Regenerate snapshots and verify full build
+
+**Objective:** Regenerate the Jest CloudFormation-template snapshots against the new `aws-cdk-lib` version, manually review the diff for anything beyond expected drift, and run the full `npx projen build` (lint, full test suite, `package:js`, `package:python`) to confirm nothing else broke — including that `integ-tests/*.ts` still type-checks under the bumped `aws-cdk-lib`/`@aws-cdk/integ-tests-alpha`.
+
+**Files:**
+
+- Modify: `test/__snapshots__/vscode-server.test.ts.snap`
+- Modify: `API.md` (docgen output, regenerated by `npx projen build`)
+- Modify: any `src/*.ts` file needing a jsii 5.9→6.0 compatibility fix, if the build surfaces one (not expected, but in scope if it happens)
+
+**Key Decisions / Notes:**
+
+- Run `npx jest test/vscode-server.test.ts -u` to regenerate, then `git diff test/__snapshots__/` and read it — every changed line should be attributable to the `aws-cdk-lib` 2.190.0→2.261.0 bump (e.g. updated construct metadata, changed default resource properties). If anything looks security- or behavior-relevant (e.g. a changed IAM policy, a removed encryption setting), call it out explicitly in the completion report rather than silently accepting the snapshot.
+- `integ-tests/*.ts` has no hardcoded `aws-cdk-lib`/`cdk-nag` version references (confirmed during planning) — it just needs to still compile, which the full build's TypeScript step covers; no separate task needed.
+- `npx projen build` regenerates `API.md` via docgen — expect it to change (new/renamed types from the jsii bump are unlikely but possible) and let it land as part of this task rather than treating it as scope creep.
+
+**Definition of Done:**
+
+- [ ] Snapshot diff reviewed; only attributable-to-CDK-bump changes remain (or none)
+- [ ] `npx projen build` exits 0 (lint, full test suite, `package:js`, `package:python`)
+- [ ] Verify: `npx projen build`

--- a/mavogelcdkvscodeserver/README.md
+++ b/mavogelcdkvscodeserver/README.md
@@ -1,8 +1,8 @@
-![Source](https://img.shields.io/github/stars/MV-Consulting/cdk-vscode-server?logo=github&label=GitHub%20Stars)
-[![Build Status](https://github.com/MV-Consulting/cdk-vscode-server/actions/workflows/build.yml/badge.svg)](https://github.com/MV-Consulting/cdk-vscode-server/actions/workflows/build.yml)
+![Source](https://img.shields.io/github/stars/mavogel/cdk-vscode-server?logo=github&label=GitHub%20Stars)
+[![Build Status](https://github.com/mavogel/cdk-vscode-server/actions/workflows/build.yml/badge.svg)](https://github.com/mavogel/cdk-vscode-server/actions/workflows/build.yml)
 [![ESLint Code Formatting](https://img.shields.io/badge/code_style-eslint-brightgreen.svg)](https://eslint.org)
-[![Latest release](https://img.shields.io/github/release/MV-Consulting/cdk-vscode-server.svg)](https://github.com/MV-Consulting/cdk-vscode-server/releases)
-![GitHub](https://img.shields.io/github/license/MV-Consulting/cdk-vscode-server)
+[![Latest release](https://img.shields.io/github/release/mavogel/cdk-vscode-server.svg)](https://github.com/mavogel/cdk-vscode-server/releases)
+![GitHub](https://img.shields.io/github/license/mavogel/cdk-vscode-server)
 [![npm](https://img.shields.io/npm/dt/@mavogel/cdk-vscode-server?label=npm&color=orange)](https://www.npmjs.com/package/@mavogel/cdk-vscode-server)
 [![typescript](https://img.shields.io/badge/jsii-typescript-blueviolet.svg)](https://www.npmjs.com/package/@mavogel/cdk-vscode-server)
 

--- a/mavogelcdkvscodeserver/VSCodeServer.go
+++ b/mavogelcdkvscodeserver/VSCodeServer.go
@@ -2,10 +2,10 @@ package mavogelcdkvscodeserver
 
 import (
 	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
-	_init_ "github.com/MV-Consulting/cdk-vscode-server/mavogelcdkvscodeserver/jsii"
+	_init_ "github.com/mavogel/cdk-vscode-server/mavogelcdkvscodeserver/jsii"
 
 	"github.com/aws/constructs-go/constructs/v10"
-	"github.com/MV-Consulting/cdk-vscode-server/mavogelcdkvscodeserver/internal"
+	"github.com/mavogel/cdk-vscode-server/mavogelcdkvscodeserver/internal"
 )
 
 // VSCodeServer - spin it up in under 10 minutes.

--- a/mavogelcdkvscodeserver/go.mod
+++ b/mavogelcdkvscodeserver/go.mod
@@ -1,4 +1,4 @@
-module github.com/MV-Consulting/cdk-vscode-server/mavogelcdkvscodeserver
+module github.com/mavogel/cdk-vscode-server/mavogelcdkvscodeserver
 
 go 1.23
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "jsii-docgen": "^10.5.0",
         "jsii-pacmak": "^1.139.0",
         "jsii-rosetta": "~5.9.0",
-        "projen": "0.101.30",
+        "projen": "^0.99.80",
         "ts-jest": "^29.4.12",
         "ts-node": "^10.9.2",
         "typescript": "^6.0.3"
@@ -2978,693 +2978,6 @@
       "peerDependencies": {
         "constructs": "^10.5.1",
         "projen": "^0.99.34"
-      }
-    },
-    "node_modules/@mavogel/mvc-projen/node_modules/projen": {
-      "version": "0.99.80",
-      "resolved": "https://registry.npmjs.org/projen/-/projen-0.99.80.tgz",
-      "integrity": "sha512-rF4J7QZXDxeaBJtcRGHbQbykoZ1NGTlpM9mffSkt611HwZ9y4SpYydJRMMfCGAAeRV40UP8JK/m/yUhn7AtZJQ==",
-      "bundleDependencies": [
-        "@iarna/toml",
-        "case",
-        "chalk",
-        "comment-json",
-        "conventional-changelog-config-spec",
-        "dax",
-        "fast-glob",
-        "fast-json-patch",
-        "ini",
-        "parse-conflict-json",
-        "semver",
-        "xmlbuilder2",
-        "yaml",
-        "yargs"
-      ],
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@iarna/toml": "^2.2.5",
-        "case": "^1.6.3",
-        "chalk": "^4.1.2",
-        "comment-json": "4.2.2",
-        "constructs": "^10.5.0",
-        "conventional-changelog-config-spec": "^2.1.0",
-        "dax": "^0.48.3",
-        "fast-glob": "^3.3.3",
-        "fast-json-patch": "^3.1.1",
-        "ini": "^2.0.0",
-        "parse-conflict-json": "^4.0.0",
-        "semver": "^7.8.4",
-        "xmlbuilder2": "^4.0.3",
-        "yaml": "^2.2.2",
-        "yargs": "^17.7.2"
-      },
-      "bin": {
-        "projen": "bin/projen"
-      },
-      "engines": {
-        "node": ">= 16.0.0"
-      },
-      "peerDependencies": {
-        "constructs": "^10.5.0"
-      }
-    },
-    "node_modules/@mavogel/mvc-projen/node_modules/projen/node_modules/@iarna/toml": {
-      "version": "2.2.5",
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/@mavogel/mvc-projen/node_modules/projen/node_modules/@nodelib/fs.scandir": {
-      "version": "2.1.5",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.stat": "2.0.5",
-        "run-parallel": "^1.1.9"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@mavogel/mvc-projen/node_modules/projen/node_modules/@nodelib/fs.stat": {
-      "version": "2.0.5",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@mavogel/mvc-projen/node_modules/projen/node_modules/@nodelib/fs.walk": {
-      "version": "1.2.8",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.scandir": "2.1.5",
-        "fastq": "^1.6.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@mavogel/mvc-projen/node_modules/projen/node_modules/@oozcitak/dom": {
-      "version": "2.0.2",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "@oozcitak/infra": "^2.0.2",
-        "@oozcitak/url": "^3.0.0",
-        "@oozcitak/util": "^10.0.0"
-      },
-      "engines": {
-        "node": ">=20.0"
-      }
-    },
-    "node_modules/@mavogel/mvc-projen/node_modules/projen/node_modules/@oozcitak/infra": {
-      "version": "2.0.2",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "@oozcitak/util": "^10.0.0"
-      },
-      "engines": {
-        "node": ">=20.0"
-      }
-    },
-    "node_modules/@mavogel/mvc-projen/node_modules/projen/node_modules/@oozcitak/url": {
-      "version": "3.0.0",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "@oozcitak/infra": "^2.0.2",
-        "@oozcitak/util": "^10.0.0"
-      },
-      "engines": {
-        "node": ">=20.0"
-      }
-    },
-    "node_modules/@mavogel/mvc-projen/node_modules/projen/node_modules/@oozcitak/util": {
-      "version": "10.0.0",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.0"
-      }
-    },
-    "node_modules/@mavogel/mvc-projen/node_modules/projen/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@mavogel/mvc-projen/node_modules/projen/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@mavogel/mvc-projen/node_modules/projen/node_modules/argparse": {
-      "version": "2.0.1",
-      "inBundle": true,
-      "license": "Python-2.0"
-    },
-    "node_modules/@mavogel/mvc-projen/node_modules/projen/node_modules/array-timsort": {
-      "version": "1.0.3",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/@mavogel/mvc-projen/node_modules/projen/node_modules/braces": {
-      "version": "3.0.3",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "fill-range": "^7.1.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@mavogel/mvc-projen/node_modules/projen/node_modules/case": {
-      "version": "1.6.3",
-      "inBundle": true,
-      "license": "(MIT OR GPL-3.0-or-later)",
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/@mavogel/mvc-projen/node_modules/projen/node_modules/chalk": {
-      "version": "4.1.2",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@mavogel/mvc-projen/node_modules/projen/node_modules/cliui": {
-      "version": "8.0.1",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@mavogel/mvc-projen/node_modules/projen/node_modules/color-convert": {
-      "version": "2.0.1",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@mavogel/mvc-projen/node_modules/projen/node_modules/color-name": {
-      "version": "1.1.4",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/@mavogel/mvc-projen/node_modules/projen/node_modules/comment-json": {
-      "version": "4.2.2",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-timsort": "^1.0.3",
-        "core-util-is": "^1.0.3",
-        "esprima": "^4.0.1",
-        "has-own-prop": "^2.0.0",
-        "repeat-string": "^1.6.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/@mavogel/mvc-projen/node_modules/projen/node_modules/conventional-changelog-config-spec": {
-      "version": "2.1.0",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/@mavogel/mvc-projen/node_modules/projen/node_modules/core-util-is": {
-      "version": "1.0.3",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/@mavogel/mvc-projen/node_modules/projen/node_modules/dax": {
-      "version": "0.48.3",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "^5.26"
-      }
-    },
-    "node_modules/@mavogel/mvc-projen/node_modules/projen/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/@mavogel/mvc-projen/node_modules/projen/node_modules/escalade": {
-      "version": "3.2.0",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@mavogel/mvc-projen/node_modules/projen/node_modules/esprima": {
-      "version": "4.0.1",
-      "inBundle": true,
-      "license": "BSD-2-Clause",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@mavogel/mvc-projen/node_modules/projen/node_modules/fast-glob": {
-      "version": "3.3.3",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.stat": "^2.0.2",
-        "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.2",
-        "merge2": "^1.3.0",
-        "micromatch": "^4.0.8"
-      },
-      "engines": {
-        "node": ">=8.6.0"
-      }
-    },
-    "node_modules/@mavogel/mvc-projen/node_modules/projen/node_modules/fast-glob/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/@mavogel/mvc-projen/node_modules/projen/node_modules/fast-json-patch": {
-      "version": "3.1.1",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/@mavogel/mvc-projen/node_modules/projen/node_modules/fastq": {
-      "version": "1.20.1",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "reusify": "^1.0.4"
-      }
-    },
-    "node_modules/@mavogel/mvc-projen/node_modules/projen/node_modules/fill-range": {
-      "version": "7.1.1",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "to-regex-range": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@mavogel/mvc-projen/node_modules/projen/node_modules/get-caller-file": {
-      "version": "2.0.5",
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/@mavogel/mvc-projen/node_modules/projen/node_modules/has-flag": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@mavogel/mvc-projen/node_modules/projen/node_modules/has-own-prop": {
-      "version": "2.0.0",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@mavogel/mvc-projen/node_modules/projen/node_modules/ini": {
-      "version": "2.0.0",
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@mavogel/mvc-projen/node_modules/projen/node_modules/is-extglob": {
-      "version": "2.1.1",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@mavogel/mvc-projen/node_modules/projen/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@mavogel/mvc-projen/node_modules/projen/node_modules/is-glob": {
-      "version": "4.0.3",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-extglob": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@mavogel/mvc-projen/node_modules/projen/node_modules/is-number": {
-      "version": "7.0.0",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.12.0"
-      }
-    },
-    "node_modules/@mavogel/mvc-projen/node_modules/projen/node_modules/js-yaml": {
-      "version": "4.2.0",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/@mavogel/mvc-projen/node_modules/projen/node_modules/json-parse-even-better-errors": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/@mavogel/mvc-projen/node_modules/projen/node_modules/just-diff": {
-      "version": "6.0.2",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/@mavogel/mvc-projen/node_modules/projen/node_modules/just-diff-apply": {
-      "version": "5.5.0",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/@mavogel/mvc-projen/node_modules/projen/node_modules/merge2": {
-      "version": "1.4.1",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@mavogel/mvc-projen/node_modules/projen/node_modules/micromatch": {
-      "version": "4.0.8",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "braces": "^3.0.3",
-        "picomatch": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=8.6"
-      }
-    },
-    "node_modules/@mavogel/mvc-projen/node_modules/projen/node_modules/micromatch/node_modules/picomatch": {
-      "version": "2.3.2",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/@mavogel/mvc-projen/node_modules/projen/node_modules/parse-conflict-json": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "json-parse-even-better-errors": "^4.0.0",
-        "just-diff": "^6.0.0",
-        "just-diff-apply": "^5.2.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/@mavogel/mvc-projen/node_modules/projen/node_modules/queue-microtask": {
-      "version": "1.2.3",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/@mavogel/mvc-projen/node_modules/projen/node_modules/repeat-string": {
-      "version": "1.6.1",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
-    "node_modules/@mavogel/mvc-projen/node_modules/projen/node_modules/require-directory": {
-      "version": "2.1.1",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@mavogel/mvc-projen/node_modules/projen/node_modules/reusify": {
-      "version": "1.1.0",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "iojs": ">=1.0.0",
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@mavogel/mvc-projen/node_modules/projen/node_modules/run-parallel": {
-      "version": "1.2.0",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "queue-microtask": "^1.2.2"
-      }
-    },
-    "node_modules/@mavogel/mvc-projen/node_modules/projen/node_modules/semver": {
-      "version": "7.8.4",
-      "inBundle": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@mavogel/mvc-projen/node_modules/projen/node_modules/string-width": {
-      "version": "4.2.3",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@mavogel/mvc-projen/node_modules/projen/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@mavogel/mvc-projen/node_modules/projen/node_modules/supports-color": {
-      "version": "7.2.0",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@mavogel/mvc-projen/node_modules/projen/node_modules/to-regex-range": {
-      "version": "5.0.1",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-number": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=8.0"
-      }
-    },
-    "node_modules/@mavogel/mvc-projen/node_modules/projen/node_modules/undici-types": {
-      "version": "5.28.4",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/@mavogel/mvc-projen/node_modules/projen/node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/@mavogel/mvc-projen/node_modules/projen/node_modules/xmlbuilder2": {
-      "version": "4.0.3",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "@oozcitak/dom": "^2.0.2",
-        "@oozcitak/infra": "^2.0.2",
-        "@oozcitak/util": "^10.0.0",
-        "js-yaml": "^4.1.1"
-      },
-      "engines": {
-        "node": ">=20.0"
-      }
-    },
-    "node_modules/@mavogel/mvc-projen/node_modules/projen/node_modules/y18n": {
-      "version": "5.0.8",
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@mavogel/mvc-projen/node_modules/projen/node_modules/yaml": {
-      "version": "2.9.0",
-      "inBundle": true,
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
-    },
-    "node_modules/@mavogel/mvc-projen/node_modules/projen/node_modules/yargs": {
-      "version": "17.7.2",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^8.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^21.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@mavogel/mvc-projen/node_modules/projen/node_modules/yargs/node_modules/yargs-parser": {
-      "version": "21.1.1",
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -11275,9 +10588,9 @@
       "license": "MIT"
     },
     "node_modules/projen": {
-      "version": "0.101.30",
-      "resolved": "https://registry.npmjs.org/projen/-/projen-0.101.30.tgz",
-      "integrity": "sha512-a7c85cJsYe20DkcyQ08WrcpG1Umlhkpp5tZBzuVzOnXv/NXYVErZ9UU/0s2G+6E6cBEpzq9Kn+ZtSaw+MINT/w==",
+      "version": "0.99.80",
+      "resolved": "https://registry.npmjs.org/projen/-/projen-0.99.80.tgz",
+      "integrity": "sha512-rF4J7QZXDxeaBJtcRGHbQbykoZ1NGTlpM9mffSkt611HwZ9y4SpYydJRMMfCGAAeRV40UP8JK/m/yUhn7AtZJQ==",
       "bundleDependencies": [
         "@iarna/toml",
         "case",
@@ -11294,7 +10607,6 @@
         "yaml",
         "yargs"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@iarna/toml": "^2.2.5",
@@ -11303,15 +10615,15 @@
         "comment-json": "4.2.2",
         "constructs": "^10.5.0",
         "conventional-changelog-config-spec": "^2.1.0",
-        "dax": "^0.49.0",
+        "dax": "^0.48.3",
         "fast-glob": "^3.3.3",
         "fast-json-patch": "^3.1.1",
         "ini": "^2.0.0",
         "parse-conflict-json": "^4.0.0",
-        "semver": "^7.8.5",
+        "semver": "^7.8.4",
         "xmlbuilder2": "^4.0.3",
         "yaml": "^2.2.2",
-        "yargs": "^17.7.3"
+        "yargs": "^17.7.2"
       },
       "bin": {
         "projen": "bin/projen"
@@ -11325,13 +10637,11 @@
     },
     "node_modules/projen/node_modules/@iarna/toml": {
       "version": "2.2.5",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/projen/node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -11344,7 +10654,6 @@
     },
     "node_modules/projen/node_modules/@nodelib/fs.stat": {
       "version": "2.0.5",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -11353,7 +10662,6 @@
     },
     "node_modules/projen/node_modules/@nodelib/fs.walk": {
       "version": "1.2.8",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -11366,7 +10674,6 @@
     },
     "node_modules/projen/node_modules/@oozcitak/dom": {
       "version": "2.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -11380,7 +10687,6 @@
     },
     "node_modules/projen/node_modules/@oozcitak/infra": {
       "version": "2.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -11392,7 +10698,6 @@
     },
     "node_modules/projen/node_modules/@oozcitak/url": {
       "version": "3.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -11405,7 +10710,6 @@
     },
     "node_modules/projen/node_modules/@oozcitak/util": {
       "version": "10.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -11414,7 +10718,6 @@
     },
     "node_modules/projen/node_modules/ansi-regex": {
       "version": "5.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -11423,7 +10726,6 @@
     },
     "node_modules/projen/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -11438,19 +10740,16 @@
     },
     "node_modules/projen/node_modules/argparse": {
       "version": "2.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "Python-2.0"
     },
     "node_modules/projen/node_modules/array-timsort": {
       "version": "1.0.3",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/projen/node_modules/braces": {
       "version": "3.0.3",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -11462,7 +10761,6 @@
     },
     "node_modules/projen/node_modules/case": {
       "version": "1.6.3",
-      "dev": true,
       "inBundle": true,
       "license": "(MIT OR GPL-3.0-or-later)",
       "engines": {
@@ -11471,7 +10769,6 @@
     },
     "node_modules/projen/node_modules/chalk": {
       "version": "4.1.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -11487,7 +10784,6 @@
     },
     "node_modules/projen/node_modules/cliui": {
       "version": "8.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -11501,7 +10797,6 @@
     },
     "node_modules/projen/node_modules/color-convert": {
       "version": "2.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -11513,13 +10808,11 @@
     },
     "node_modules/projen/node_modules/color-name": {
       "version": "1.1.4",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/projen/node_modules/comment-json": {
       "version": "4.2.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -11535,19 +10828,16 @@
     },
     "node_modules/projen/node_modules/conventional-changelog-config-spec": {
       "version": "2.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/projen/node_modules/core-util-is": {
       "version": "1.0.3",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/projen/node_modules/dax": {
-      "version": "0.49.0",
-      "dev": true,
+      "version": "0.48.3",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -11556,13 +10846,11 @@
     },
     "node_modules/projen/node_modules/emoji-regex": {
       "version": "8.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/projen/node_modules/escalade": {
       "version": "3.2.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -11571,7 +10859,6 @@
     },
     "node_modules/projen/node_modules/esprima": {
       "version": "4.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "bin": {
@@ -11584,7 +10871,6 @@
     },
     "node_modules/projen/node_modules/fast-glob": {
       "version": "3.3.3",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -11600,7 +10886,6 @@
     },
     "node_modules/projen/node_modules/fast-glob/node_modules/glob-parent": {
       "version": "5.1.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -11612,13 +10897,11 @@
     },
     "node_modules/projen/node_modules/fast-json-patch": {
       "version": "3.1.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/projen/node_modules/fastq": {
       "version": "1.20.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -11627,7 +10910,6 @@
     },
     "node_modules/projen/node_modules/fill-range": {
       "version": "7.1.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -11639,7 +10921,6 @@
     },
     "node_modules/projen/node_modules/get-caller-file": {
       "version": "2.0.5",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -11648,7 +10929,6 @@
     },
     "node_modules/projen/node_modules/has-flag": {
       "version": "4.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -11657,7 +10937,6 @@
     },
     "node_modules/projen/node_modules/has-own-prop": {
       "version": "2.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -11666,7 +10945,6 @@
     },
     "node_modules/projen/node_modules/ini": {
       "version": "2.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -11675,7 +10953,6 @@
     },
     "node_modules/projen/node_modules/is-extglob": {
       "version": "2.1.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -11684,7 +10961,6 @@
     },
     "node_modules/projen/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -11693,7 +10969,6 @@
     },
     "node_modules/projen/node_modules/is-glob": {
       "version": "4.0.3",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -11705,7 +10980,6 @@
     },
     "node_modules/projen/node_modules/is-number": {
       "version": "7.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -11713,8 +10987,7 @@
       }
     },
     "node_modules/projen/node_modules/js-yaml": {
-      "version": "4.3.1",
-      "dev": true,
+      "version": "4.2.0",
       "funding": [
         {
           "type": "github",
@@ -11736,7 +11009,6 @@
     },
     "node_modules/projen/node_modules/json-parse-even-better-errors": {
       "version": "4.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -11745,19 +11017,16 @@
     },
     "node_modules/projen/node_modules/just-diff": {
       "version": "6.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/projen/node_modules/just-diff-apply": {
       "version": "5.5.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/projen/node_modules/merge2": {
       "version": "1.4.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -11766,7 +11035,6 @@
     },
     "node_modules/projen/node_modules/micromatch": {
       "version": "4.0.8",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -11779,7 +11047,6 @@
     },
     "node_modules/projen/node_modules/micromatch/node_modules/picomatch": {
       "version": "2.3.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -11791,7 +11058,6 @@
     },
     "node_modules/projen/node_modules/parse-conflict-json": {
       "version": "4.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -11805,7 +11071,6 @@
     },
     "node_modules/projen/node_modules/queue-microtask": {
       "version": "1.2.3",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -11825,7 +11090,6 @@
     },
     "node_modules/projen/node_modules/repeat-string": {
       "version": "1.6.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -11834,7 +11098,6 @@
     },
     "node_modules/projen/node_modules/require-directory": {
       "version": "2.1.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -11843,7 +11106,6 @@
     },
     "node_modules/projen/node_modules/reusify": {
       "version": "1.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -11853,7 +11115,6 @@
     },
     "node_modules/projen/node_modules/run-parallel": {
       "version": "1.2.0",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -11875,8 +11136,7 @@
       }
     },
     "node_modules/projen/node_modules/semver": {
-      "version": "7.8.5",
-      "dev": true,
+      "version": "7.8.4",
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -11888,7 +11148,6 @@
     },
     "node_modules/projen/node_modules/string-width": {
       "version": "4.2.3",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -11902,7 +11161,6 @@
     },
     "node_modules/projen/node_modules/strip-ansi": {
       "version": "6.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -11914,7 +11172,6 @@
     },
     "node_modules/projen/node_modules/supports-color": {
       "version": "7.2.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -11926,7 +11183,6 @@
     },
     "node_modules/projen/node_modules/to-regex-range": {
       "version": "5.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -11938,13 +11194,11 @@
     },
     "node_modules/projen/node_modules/undici-types": {
       "version": "5.28.4",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/projen/node_modules/wrap-ansi": {
       "version": "7.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -11961,7 +11215,6 @@
     },
     "node_modules/projen/node_modules/xmlbuilder2": {
       "version": "4.0.3",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -11976,7 +11229,6 @@
     },
     "node_modules/projen/node_modules/y18n": {
       "version": "5.0.8",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -11985,7 +11237,6 @@
     },
     "node_modules/projen/node_modules/yaml": {
       "version": "2.9.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -11999,8 +11250,7 @@
       }
     },
     "node_modules/projen/node_modules/yargs": {
-      "version": "17.7.3",
-      "dev": true,
+      "version": "17.7.2",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -12018,7 +11268,6 @@
     },
     "node_modules/projen/node_modules/yargs/node_modules/yargs-parser": {
       "version": "21.1.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Running VS Code Server on AWS",
   "repository": {
     "type": "git",
-    "url": "https://github.com/MV-Consulting/cdk-vscode-server.git"
+    "url": "https://github.com/mavogel/cdk-vscode-server.git"
   },
   "scripts": {
     "build": "projen build",
@@ -81,7 +81,7 @@
     "jsii-docgen": "^10.5.0",
     "jsii-pacmak": "^1.139.0",
     "jsii-rosetta": "~5.9.0",
-    "projen": "0.101.30",
+    "projen": "^0.99.80",
     "ts-jest": "^29.4.12",
     "ts-node": "^10.9.2",
     "typescript": "^6.0.3"


### PR DESCRIPTION
## Summary

- Repoints org references (`MV-Consulting` → `mavogel`) across `.projenrc.ts`, `README.md`, and the generated Go artifacts, plus the local git remote.
- Fixes the `npx projen release` CI failure (`Cannot find module '.../bump-version.task.js'`) caused by a `projen` version mismatch between the top-level devDependency and `@mavogel/mvc-projen`'s nested pin — realigns to a single deduped `projen@0.99.80` install and excludes `projen` from the automated weekly upgrade task so it can't drift out of sync again.
- Adds an **approved, not-yet-implemented** plan (`docs/plans/2026-08-09-cdk-nag-v3-migration.md`) for a follow-up: upgrading `@mavogel/mvc-projen` to latest (`^0.0.30`), bumping `aws-cdk-lib` to `2.261.0`, and migrating cdk-nag v2 → v3. That work is deliberately deferred to a separate PR since it's a larger, higher-risk migration (cdk-nag v3 removes the `NagSuppressions` API entirely).

## Verification

- `npx projen build` passes (lint, full test suite — 38 passed/1 skipped, package:js, package:python).
- Reproduced the original CI failure locally and confirmed the fix: `CI=true npx projen release` now completes the bump-version step instead of crashing.
- Reviewed by the `changes-review` sub-agent; one `must_fix` (an over-broad org-rename touching a third-party Go module path) was caught and fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)